### PR TITLE
Fixed Makefile for Xcode 4.6 / iOS SDK 6.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-TARGET = iphone:5.1
+TARGET = iphone:6.1
+
+export ARCHS=armv7
+export TARGET=iphone:latest:4.3
+
 include theos/makefiles/common.mk
 
 TWEAK_NAME = SSLKillSwitch


### PR DESCRIPTION
Make fails due to linker errors with newer versions of Xcode / iOS SDK, this should fix the issue.
